### PR TITLE
Implement support for CODE and QUOTE spanning multiple lines

### DIFF
--- a/public/js/markdown.js
+++ b/public/js/markdown.js
@@ -188,7 +188,7 @@ var Markdown = function() {
 
         };
       } else {
-        _.each(["unorderedList", "orderedList", "codeIndent"], function(method) {
+        _.each(["unorderedList", "orderedList", "codeIndent", "quoteBlock"], function(method) {
           /*
             re = {
               to: 5,
@@ -225,6 +225,23 @@ var Markdown = function() {
     }).join("\n");
   };
 
+
+  /*
+    Converts Markdown multi-line quotes into single BBCode quote block
+    @lines Array<String> A list of lines. Each line is in Markdown.
+    @n Integer On what position should we start looking for a markdown quotes?
+    @return Hash Take a look at the #renderBlock method for more information.
+  */
+  self.quoteBlock = function(lines, n) {
+    var template = _.template("[QUOTE]<% for (var i = 0, length = list.length; i < length; i++){ %>\n<%= list[i] %><% }; %>\n[/QUOTE]");
+    return self.renderBlock({
+      template: template,
+      lines: lines,
+      n: n,
+      match: /^>\s*([^\n]+)/,
+      remove: /^>\s*/
+    });
+  };
 
   /*
     Converts Markdown multiple indented lines into single BBCode code block

--- a/public/js/markdown.js
+++ b/public/js/markdown.js
@@ -232,11 +232,11 @@ var Markdown = function() {
     Converts Markdown unordered lists into BBCode lists.
     @lines Array<String> A list of lines. Each line is in Markdown.
     @n Integer On what position should we start looking for a markdown list?
-    @return Hash Take a look at the #renderList method for more information.
+    @return Hash Take a look at the #renderBlock method for more information.
   */
   self.unorderedList = function(lines, n) {
     var template = _.template("[LIST]<% for (var i = 0, length = list.length; i < length; i++){ %>\n[*]<%= list[i] %><% }; %>\n[/LIST]");
-    return self.renderList({
+    return self.renderBlock({
       template: template,
       lines: lines,
       n: n,
@@ -249,11 +249,11 @@ var Markdown = function() {
     Converts Markdown ordered lists into BBCode lists.
     @lines Array<String> A list of lines. Each line is in Markdown.
     @n Integer On what position should we start looking for a markdown list?
-    @return Hash Take a look at the #renderList method for more information.
+    @return Hash Take a look at the #renderBlock method for more information.
   */
   self.orderedList = function(lines, n) {
     var template = _.template("[LIST=1]<% for (var i = 0, length = list.length; i < length; i++){ %>\n[*]<%= list[i] %><% }; %>\n[/LIST]");
-    return self.renderList({
+    return self.renderBlock({
       template: template,
       lines: lines,
       n: n,
@@ -263,8 +263,8 @@ var Markdown = function() {
   };
 
   /*
-  @options Hash A hash of options used for rendering a markdown list
-  Example list:
+  @options Hash A hash of options used for rendering a markdown block
+  Example:
     options {
       template: "a template",
       n: 1,
@@ -274,28 +274,28 @@ var Markdown = function() {
     }
     
     @template A underscore.js template
-    @n Where #renderList should start look for a list
+    @n Where #renderBlock should start look for a block
     @lines A list of lines for the entire document
-    @match How do we know what a list item looks like?
-    @remove What should be striped out before we can call it a list item?
+    @match How do we know what a block item looks like?
+    @remove What should be striped out before we can call it a block item?
   @return Hash 
     return {
       found: true,
       data: data,
       to: i
     };
-    @found Did we find a list?
-    @data How does the new, BBCode list looks like?
-    @to On what line does the list end?
+    @found Did we find a block?
+    @data How does the new, BBCode block looks like?
+    @to On what line does the block end?
   */
-  self.renderList = function(options) {
+  self.renderBlock = function(options) {
     var template, i, matches, lines, length;
 
     template = options.template;
     lines = options.lines;
 
     for (i = options.n, length = lines.length; i < length; i++) {
-      /* Is this a list item ?*/
+      /* Is this a block line ?*/
       if (lines[i].match(options.match)) {
         matches = [lines[i].replace(options.remove, "")];
         for (i = (i + 1); i < length; i++) {
@@ -307,7 +307,7 @@ var Markdown = function() {
         };
 
         /* 
-          This is the end of the list
+          This is the end of the block
           Let's render it!
         */
         data = template({

--- a/spec/spec/ApplicationSpec.js
+++ b/spec/spec/ApplicationSpec.js
@@ -38,6 +38,11 @@ describe("Markdown", function() {
     it("it should handle an author - 2", function() {
       expect(converter.quote("John Doe > This is a quote!")).toEqual('[QUOTE="John Doe"]\nThis is a quote!\n[/QUOTE]');
     });
+
+    it("supports multiple consecutive quote lines", function() {
+      var list = ["> This is quote!", "> Second line"]
+      expect(converter.quoteBlock(list, 0).data).toEqual('[QUOTE]\nThis is quote!\nSecond line\n[/QUOTE]');
+    });
   });
 
   describe("#image", function() {

--- a/spec/spec/ApplicationSpec.js
+++ b/spec/spec/ApplicationSpec.js
@@ -71,12 +71,14 @@ describe("Markdown", function() {
       expect(converter.code("``` random\nCode!\n```")).toEqual('[CODE]\nCode!\n[/CODE]');
     });
 
-    it("converters markdown 4 space indent to a BBCode tag, start with a new line", function() {
-      expect(converter.code("\n    This is code!")).toEqual('\n[CODE]\nThis is code!\n[/CODE]');
+    it("converters markdown 4 space indent to a BBCode tag", function() {
+      var list = ["    This is code!"]
+      expect(converter.codeIndent(list, 0).data).toEqual('[CODE]\nThis is code!\n[/CODE]');
     });
 
-    it("converters markdown 4 space indent to a BBCode tag, start and end with a new line", function() {
-      expect(converter.code("\n    This is code!\n")).toEqual('\n[CODE]\nThis is code!\n[/CODE]\n');
+    it("converters markdown 4 space indent to a BBCode tag, check multiple consecutive lines", function() {
+      var list = ["    This is code!", "    Line 2"]
+      expect(converter.codeIndent(list, 0).data).toEqual('[CODE]\nThis is code!\nLine 2\n[/CODE]');
     });
   });
 


### PR DESCRIPTION
Please merge branch `block-elems` into `master`. This branch adds support for markdown elements that span multiple lines, such as indented code and quotes.

There are three commits. 

7f4d7c5 changes function name from renderList into renderBlock, so end-user is not confused about purpose of function. This one must be applied for other commits to apply cleanly.

f857aee add support for multiline code block and a88a7ad adds support for multiline quotes. They can be applied separately if one of changes is not desired for any reason.
