### PR TITLE
Fix regular expression for code blocks

### DIFF
--- a/public/js/markdown.js
+++ b/public/js/markdown.js
@@ -121,7 +121,7 @@ var Markdown = function() {
   self.code = function(content) {
     var regexp, template, getType;
 
-    regexp = /```\s*(([^\n]+))?\n([^```]+)```/gm;
+    regexp = /```[ \f\t\v\u00a0\u1680\u180e\u2000-\u200a\u2028\u2029\u202f\u205f\u3000\ufeff]*(([^\n]+))?\n([\s\S]+?(?=\n```))\n```/gm;
     template = _.template("[<%= type %>]\n<%= content %>\n[/<%= type %>]");
 
     getType = function(match) {

--- a/spec/spec/ApplicationSpec.js
+++ b/spec/spec/ApplicationSpec.js
@@ -76,6 +76,18 @@ describe("Markdown", function() {
       expect(converter.code("``` random\nCode!\n```")).toEqual('[CODE]\nCode!\n[/CODE]');
     });
 
+    it("supports multiple lines without language annotation", function() {
+      expect(converter.code("```\nfirst line\nsecond line\n```")).toEqual('[CODE]\nfirst line\nsecond line\n[/CODE]');
+    });
+
+    it("doesn't treat first line as language annotation", function() {
+      expect(converter.code("```\nfirst line\nsecond line\n```")).not.toEqual('[CODE]\nsecond line\n[/CODE]');
+    });
+
+    it("allows single backtick in code block", function() {
+      expect(converter.code("```\nain`t\n```")).toEqual('[CODE]\nain`t\n[/CODE]');
+    });
+
     it("converters markdown 4 space indent to a BBCode tag", function() {
       var list = ["    This is code!"]
       expect(converter.codeIndent(list, 0).data).toEqual('[CODE]\nThis is code!\n[/CODE]');


### PR DESCRIPTION
Please merge branch `code-block-regexp-fix` into `master`. It fixes two issues related to markdown code blocks denoted by triple backtick character. Details in commit message and tests suite.
